### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # This repo is owned by the universal-publishing team, which is  administered by the FT Content Programme Team.
 * @Financial-Times/universal-publishing
+
+# This repo is supported by:
+* @Financial-Times/metadata-team


### PR DESCRIPTION
We need to add a second record in CODEOWNERS file (located in .github folder) in
all C&M repos. The Reason is that currently the whole C&M is notified for every new
PR.

This PR updates the file with a second record. If you can verify that the sub
team responsible for this repo is correct to approve and merge the PR.